### PR TITLE
Add MySQL connection helper

### DIFF
--- a/componentes/helpers/conexion_bd.py
+++ b/componentes/helpers/conexion_bd.py
@@ -1,0 +1,16 @@
+import mysql.connector
+from mysql.connector import Error
+
+def obtener_conexion():
+    """Crea y devuelve una conexion a la base de datos."""
+    try:
+        conexion = mysql.connector.connect(
+            host="localhost",
+            user="root",
+            password="",
+            database="palmatronica",
+        )
+        return conexion
+    except Error as e:
+        print(f"Error al conectar a la base de datos: {e}")
+        return None


### PR DESCRIPTION
## Summary
- add a Python helper in `componentes/helpers` for connecting to the `palmatronica` database

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68784ad6f7888322ba8daac3238c8821