### PR TITLE
Add admin start page with cards

### DIFF
--- a/static/css/inicio.admin.css
+++ b/static/css/inicio.admin.css
@@ -1,0 +1,86 @@
+:root {
+  --bg-image: url('../img/background.jpg');
+  --card-bg: rgba(0,0,0,0.45);
+  --blur-bg: rgba(255,255,255,0.05);
+  --text-color: #e0e0e0;
+  --accent: #2fdcdc;
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-image: var(--bg-image);
+  background-size: cover;
+  background-position: center;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: var(--text-color);
+}
+
+.main-container {
+  backdrop-filter: blur(8px);
+  background-color: var(--card-bg);
+  padding: 2rem 3rem;
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.logo {
+  max-width: 220px;
+}
+
+.cards {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.card {
+  background-color: var(--blur-bg);
+  padding: 2rem;
+  border-radius: var(--radius);
+  width: 260px;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.card:hover {
+  background-color: rgba(255,255,255,0.15);
+}
+
+.dropdown {
+  display: none;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.card.active .dropdown {
+  display: flex;
+}
+
+.dropdown button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  background-color: var(--accent);
+  color: #000;
+  cursor: pointer;
+}
+
+.dropdown button:hover {
+  background-color: #21b5b5;
+}

--- a/static/js/inicio.admin.js
+++ b/static/js/inicio.admin.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const newOrderCard = document.getElementById('new-order-card');
+  if (newOrderCard) {
+    newOrderCard.addEventListener('click', (e) => {
+      newOrderCard.classList.toggle('active');
+    });
+  }
+});

--- a/templates/inicio.admin.html
+++ b/templates/inicio.admin.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inicio Administrador</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/inicio.admin.css') }}">
+  <script src="{{ url_for('static', filename='js/inicio.admin.js') }}" defer></script>
+</head>
+<body>
+  <div class="main-container">
+    <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo">
+    <div class="cards">
+      <div class="card" id="new-order-card">
+        <h2>Crear Orden de Servicio</h2>
+        <div class="dropdown">
+          <button>Computador</button>
+          <button>Celular</button>
+        </div>
+      </div>
+      <div class="card" id="history-card">
+        <h2>Historial de Servicios</h2>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `inicio.admin.html` template
- add styles for admin start page
- add JS to toggle dropdown on new order card

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d4855fa088322b322338e4ada0804