### PR TITLE
Implement logout and login navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,12 @@ def clientes_inicio():
     return render_template("user/inicio_user.html")
 
 
+@app.route('/logout')
+def logout():
+    """Cierra la sesión actual y vuelve al inicio de sesión."""
+    return redirect(url_for('index'))
+
+
 @app.route('/registrarse', methods=['GET', 'POST'])
 def registrarse():
     if request.method == 'POST':

--- a/static/css/inicio.admin.css
+++ b/static/css/inicio.admin.css
@@ -87,3 +87,20 @@ body {
 .dropdown button:hover {
   background-color: #21b5b5;
 }
+
+.btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--accent);
+  color: #000;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: var(--radius);
+  display: inline-block;
+  text-transform: uppercase;
+}
+
+.btn:hover {
+  background-color: #21b5b5;
+}

--- a/static/css/inicio.user.css
+++ b/static/css/inicio.user.css
@@ -31,3 +31,20 @@ body {
   padding: 2rem 3rem;
   border-radius: var(--radius);
 }
+
+.btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--accent);
+  color: #000;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: var(--radius);
+  display: inline-block;
+  text-transform: uppercase;
+}
+
+.btn:hover {
+  background-color: #21b5b5;
+}

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -74,7 +74,8 @@ body {
   font-size: 0.9rem;
 }
 
-button[type="submit"] {
+button[type="submit"],
+.btn {
   margin-top: var(--gap);
   width: 100%;
   padding: 0.5rem;
@@ -86,6 +87,9 @@ button[type="submit"] {
   border: none;
   border-radius: var(--radius);
   cursor: pointer;
+  text-decoration: none;
+  display: block;
+  text-align: center;
 }
 
 .login-link,

--- a/static/css/registro.css
+++ b/static/css/registro.css
@@ -75,7 +75,8 @@ body {
   font-size: 0.9rem;
 }
 
-button[type="submit"] {
+button[type="submit"],
+.btn {
   margin-top: var(--gap);
   width: 100%;
   padding: 0.5rem;
@@ -87,6 +88,9 @@ button[type="submit"] {
   border: none;
   border-radius: var(--radius);
   cursor: pointer;
+  text-decoration: none;
+  display: block;
+  text-align: center;
 }
 
 .login-link,

--- a/templates/admin/inicio_admin.html
+++ b/templates/admin/inicio_admin.html
@@ -8,20 +8,21 @@
   <script src="{{ url_for('static', filename='js/inicio.admin.js') }}" defer></script>
 </head>
 <body>
-  <div class="main-container">
-    <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo">
-    <div class="cards">
-      <div class="card" id="new-order-card">
-        <h2>Crear Orden de Servicio</h2>
-        <div class="dropdown">
-          <button>Computador</button>
-          <button>Celular</button>
+    <div class="main-container">
+      <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo">
+      <div class="cards">
+        <div class="card" id="new-order-card">
+          <h2>Crear Orden de Servicio</h2>
+          <div class="dropdown">
+            <button>Computador</button>
+            <button>Celular</button>
+          </div>
+        </div>
+        <div class="card" id="history-card">
+          <h2>Historial de Servicios</h2>
         </div>
       </div>
-      <div class="card" id="history-card">
-        <h2>Historial de Servicios</h2>
-      </div>
+      <a href="{{ url_for('logout') }}" class="btn">Cerrar sesión</a>
     </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/templates/registro.html
+++ b/templates/registro.html
@@ -25,7 +25,7 @@
       <p class="error">{{ error_id }}</p>
     {% endif %}
 
-    <form class="login-form" action="{{ url_for('registrarse') }}" method="post">
+      <form class="login-form" action="{{ url_for('registrarse') }}" method="post">
       <h1>Crear cuenta</h1>
 
       <!-- Errores de validación -->
@@ -156,12 +156,13 @@
         >
       </div>
 
-      <button type="submit">Registrarse</button>
+        <button type="submit">Registrarse</button>
+        <a href="{{ url_for('index') }}" class="btn">Volver al login</a>
 
-      <a href="{{ url_for('index') }}" class="login-link">
-        ¿Ya tienes cuenta? <strong>Inicia sesión</strong>
-      </a>
-    </form>
-  </div>
-</body>
+        <a href="{{ url_for('index') }}" class="login-link">
+          ¿Ya tienes cuenta? <strong>Inicia sesión</strong>
+        </a>
+      </form>
+    </div>
+  </body>
 </html>

--- a/templates/user/inicio_user.html
+++ b/templates/user/inicio_user.html
@@ -9,6 +9,7 @@
 <body>
     <div class="main-container">
         <p>hola cliente</p>
+        <a href="{{ url_for('logout') }}" class="btn">Cerrar sesión</a>
     </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/logout` route for redirecting back to login
- show a **Cerrar sesión** button for admin and user pages
- add "Volver al login" button on register page
- share button styling across pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(launched and confirmed server start)*

------
https://chatgpt.com/codex/tasks/task_e_688c3f9755d083229f26d388a641e7df