### PR TITLE
Rework admin pages

### DIFF
--- a/static/css/nueva_orden.css
+++ b/static/css/nueva_orden.css
@@ -1,0 +1,73 @@
+:root {
+  --bg-image: url('../img/bck.png');
+  --card-bg: rgba(0,0,0,0.45);
+  --text-color: #e0e0e0;
+  --accent: #2fdcdc;
+  --radius: 8px;
+  --gap: 0.8rem;
+}
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-image: var(--bg-image);
+  background-size: cover;
+  background-position: center;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: var(--text-color);
+  padding: var(--gap);
+}
+.main-container {
+  backdrop-filter: blur(8px);
+  background-color: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem 3rem;
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+  width: 100%;
+  max-width: 500px;
+}
+.order-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+.form-group input,
+.form-group textarea {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid #444;
+  background-color: rgba(42,42,42,0.8);
+  color: var(--text-color);
+}
+button[type="submit"],
+.btn {
+  margin-top: var(--gap);
+  padding: 0.5rem;
+  background-color: var(--accent);
+  color: #000;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+}
+.btn:hover,
+button[type="submit"]:hover {
+  background-color: #21b5b5;
+}

--- a/static/js/inicio.admin.js
+++ b/static/js/inicio.admin.js
@@ -1,8 +1,23 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const newOrderCard = document.getElementById('new-order-card');
-  if (newOrderCard) {
-    newOrderCard.addEventListener('click', (e) => {
-      newOrderCard.classList.toggle('active');
-    });
-  }
+  document.querySelectorAll('.card').forEach(card => {
+    const url = card.dataset.url;
+    if (card.id === 'new-order-card') {
+      card.addEventListener('click', () => {
+        card.classList.toggle('active');
+      });
+      card.querySelectorAll('.dropdown button').forEach(btn => {
+        btn.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          if (url) {
+            const tipo = btn.dataset.type;
+            window.location.href = `${url}?tipo=${tipo}`;
+          }
+        });
+      });
+    } else if (url) {
+      card.addEventListener('click', () => {
+        window.location.href = url;
+      });
+    }
+  });
 });

--- a/static/js/nueva_orden.js
+++ b/static/js/nueva_orden.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const idInput = document.getElementById('id_usuario');
+  const campos = {
+    nombre: document.getElementById('nombre'),
+    apellido: document.getElementById('apellido'),
+    correo: document.getElementById('correo'),
+    telefono: document.getElementById('telefono'),
+    direccion: document.getElementById('direccion'),
+  };
+
+  idInput.addEventListener('change', () => {
+    const id = idInput.value.trim();
+    if (!id) return;
+    fetch(`/api/usuario/${id}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data) {
+          campos.nombre.value = data.nombre || '';
+          campos.apellido.value = data.apellido || '';
+          campos.correo.value = data.correo || '';
+          campos.telefono.value = data.telefono || '';
+          campos.direccion.value = data.direccion || '';
+        } else {
+          Object.values(campos).forEach(c => c.value = '');
+        }
+      });
+  });
+});

--- a/templates/admin/inicio_admin.html
+++ b/templates/admin/inicio_admin.html
@@ -11,14 +11,17 @@
     <div class="main-container">
       <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo">
       <div class="cards">
-        <div class="card" id="new-order-card">
+        <div class="card" id="register-card" data-url="{{ url_for('registrarse') }}">
+          <h2>Registrar Usuario</h2>
+        </div>
+        <div class="card" id="new-order-card" data-url="{{ url_for('nueva_orden') }}">
           <h2>Crear Orden de Servicio</h2>
           <div class="dropdown">
-            <button>Computador</button>
-            <button>Celular</button>
+            <button data-type="computador">Computador</button>
+            <button data-type="celular">Celular</button>
           </div>
         </div>
-        <div class="card" id="history-card">
+        <div class="card" id="history-card" data-url="#">
           <h2>Historial de Servicios</h2>
         </div>
       </div>

--- a/templates/admin/nueva_orden.html
+++ b/templates/admin/nueva_orden.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nueva Orden</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/nueva_orden.css') }}">
+  <script src="{{ url_for('static', filename='js/nueva_orden.js') }}" defer></script>
+</head>
+<body>
+  <div class="main-container">
+    <h1>Nueva Orden de Servicio</h1>
+    <form action="{{ url_for('nueva_orden') }}" method="post" class="order-form">
+      <input type="hidden" name="tipo" value="{{ tipo }}">
+      <div class="form-group">
+        <label for="id_usuario" class="sr-only">ID Usuario</label>
+        <input type="text" id="id_usuario" name="id_usuario" placeholder="Número de identificación" required>
+      </div>
+      <div class="form-group">
+        <label>Nombre</label>
+        <input type="text" id="nombre" readonly>
+      </div>
+      <div class="form-group">
+        <label>Apellido</label>
+        <input type="text" id="apellido" readonly>
+      </div>
+      <div class="form-group">
+        <label>Correo</label>
+        <input type="text" id="correo" readonly>
+      </div>
+      <div class="form-group">
+        <label>Teléfono</label>
+        <input type="text" id="telefono" readonly>
+      </div>
+      <div class="form-group">
+        <label>Dirección</label>
+        <input type="text" id="direccion" readonly>
+      </div>
+      <div class="form-group">
+        <label for="descripcion" class="sr-only">Descripción de la falla</label>
+        <textarea id="descripcion" name="descripcion" placeholder="Descripción de la falla" required></textarea>
+      </div>
+      <button type="submit">Crear Orden</button>
+      <a href="{{ url_for('inicio_admin') }}" class="btn">Volver</a>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -35,10 +35,6 @@
       </p>
 
       <button type="submit">Iniciar sesión</button>
-
-      <a href="{{ url_for('registrarse') }}" class="login-link">
-        ¿No tienes cuenta? <strong>Registrate aqui</strong>
-      </a>
     </form>
   </div>
 </body>

--- a/templates/registro.html
+++ b/templates/registro.html
@@ -32,9 +32,6 @@
       {% if error_email %}
         <p class="error">{{ error_email }}</p>
       {% endif %}
-      {% if error_pwd %}
-        <p class="error">{{ error_pwd }}</p>
-      {% endif %}
 
       <div class="login-input">
         <label for="nombre" class="sr-only">Nombre</label>
@@ -128,40 +125,9 @@
         >
       </div>
 
-      <div class="login-input">
-        <label for="palabra_cliente" class="sr-only">Contraseña</label>
-        <input
-          type="password"
-          id="palabra_cliente"
-          name="palabra_cliente"
-          placeholder="Ingresa tu contraseña"
-          maxlength="16"
-          minlength="8"
-          pattern="[a-zA-Z0-9]{8,16}"
-          title="La contraseña debe tener entre 8 y 16 caracteres alfanuméricos."
-          required
-        >
-      </div>
-
-      <div class="login-input">
-        <label for="password_cliente_conf" class="sr-only">Confirma tu contraseña</label>
-        <input
-          type="password"
-          id="password_cliente_conf"
-          name="password_cliente_conf"
-          placeholder="Confirma tu contraseña"
-          maxlength="16"
-          minlength="8"
-          required
-        >
-      </div>
 
         <button type="submit">Registrarse</button>
-        <a href="{{ url_for('index') }}" class="btn">Volver al login</a>
-
-        <a href="{{ url_for('index') }}" class="login-link">
-          ¿Ya tienes cuenta? <strong>Inicia sesión</strong>
-        </a>
+        <a href="{{ url_for('inicio_admin') }}" class="btn">Volver</a>
       </form>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- tidy login by removing register link
- simplify registration form (no passwords)
- support admin actions from home page and add registration
- add routes and pages for creating service orders
- show user data automatically while creating orders

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688d1a962bd88322893f719ed1783be4