### PR TITLE
feat: add white background to new order page

### DIFF
--- a/static/css/nueva_orden.css
+++ b/static/css/nueva_orden.css
@@ -1,6 +1,6 @@
 :root{
   --bg: #000000;
-  --text: #e8f2f2;
+  --text: #000000;
   --muted: #a8b7b7;
   --field-bg: #0f1111;
   --field-br: #242a2a;
@@ -15,8 +15,9 @@
 html,body{ height:100%; }
 body{
   margin:0;
-  background: var(--bg);
-  color: var(--text);
+  background: url('../img/white_bck.png') no-repeat center center fixed;
+  background-size: cover;
+  color: #000;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
   line-height: 1.35;
 }


### PR DESCRIPTION
## Summary
- use white_bck.png as background for new order page
- ensure text renders black by default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893d109dd4c8322ace9be4efb0d0158