### PR TITLE
Refine service order form styling and inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ def nueva_orden():
         conexion.commit()
         cursor.close()
         conexion.close()
-        flash('Orden creada correctamente')
+        flash(f'Orden creada correctamente. Número de orden: {id_orden}')
         return redirect(url_for('inicio_admin'))
 
     tipo = request.args.get('tipo', '')

--- a/static/css/nueva_orden.css
+++ b/static/css/nueva_orden.css
@@ -9,6 +9,8 @@
   --field-br-focus: #60C6ED;
   --accent: #60C6ED;
   --line: #60C6ED;
+  --black: #000000;
+  --white: #FFFFFF;
   --radius: 12px;
   --gap: 14px;
 }
@@ -72,8 +74,8 @@ body{
   text-transform: uppercase;
   font-size: 14px;
   letter-spacing: .08em;
-  background-color: var(--accent);
-  color: var(--text);
+  background-color: var(--black);
+  color: var(--white);
   padding: 4px 8px;
   display: inline-block;
 }
@@ -102,6 +104,29 @@ body{
   height:1px; width:1px;
   overflow:hidden; clip:rect(1px, 1px, 1px, 1px);
   white-space:nowrap; border:0; padding:0; margin:-1px;
+}
+
+/* Mostrar etiquetas dentro del checklist */
+.checklist .field label{
+  height: auto;
+  width: auto;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  margin: 0 0 6px;
+}
+
+.checklist .field{
+  display: flex;
+  flex-direction: column;
+}
+
+.checklist .field select{
+  padding: 8px;
+  border: 1px solid var(--field-br);
+  border-radius: var(--radius);
+  background: var(--field-bg);
+  color: var(--text);
 }
 
 .terms{

--- a/templates/admin/nueva_orden.html
+++ b/templates/admin/nueva_orden.html
@@ -71,33 +71,116 @@
     <section class="section">
       <h2 class="section__title">Checklist</h2>
       <div class="checklist grid grid--2">
-        <!-- Columna izquierda -->
-        <label class="check"><input type="checkbox" name="pantalla" /> <span>Pantalla</span></label>
-        <label class="check"><input type="checkbox" name="face_id" /> <span>Face ID</span></label>
+        <div class="field">
+          <label for="pantalla">Pantalla</label>
+          <select id="pantalla" name="pantalla">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="face_id">Face ID</label>
+          <select id="face_id" name="face_id">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
 
-        <label class="check"><input type="checkbox" name="tactil" /> <span>Táctil</span></label>
-        <label class="check"><input type="checkbox" name="carga" /> <span>Carga</span></label>
+        <div class="field">
+          <label for="tactil">Táctil</label>
+          <select id="tactil" name="tactil">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="carga">Carga</label>
+          <select id="carga" name="carga">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
 
-        <label class="check"><input type="checkbox" name="backlight" /> <span>Backlight</span></label>
-        <label class="check"><input type="checkbox" name="carga_inalambrica" /> <span>Carga inalámbrica</span></label>
+        <div class="field">
+          <label for="backlight">Backlight</label>
+          <select id="backlight" name="backlight">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="carga_inalambrica">Carga inalámbrica</label>
+          <select id="carga_inalambrica" name="carga_inalambrica">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
 
-        <label class="check"><input type="checkbox" name="camara_trasera" /> <span>Cámara trasera</span></label>
-        <label class="check"><input type="checkbox" name="auricular" /> <span>Auricular</span></label>
+        <div class="field">
+          <label for="camara_trasera">Cámara trasera</label>
+          <select id="camara_trasera" name="camara_trasera">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="auricular">Auricular</label>
+          <select id="auricular" name="auricular">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
 
-        <label class="check"><input type="checkbox" name="camara_delantera" /> <span>Cámara delantera</span></label>
-        <label class="check"><input type="checkbox" name="microfono" /> <span>Micrófono</span></label>
+        <div class="field">
+          <label for="camara_delantera">Cámara delantera</label>
+          <select id="camara_delantera" name="camara_delantera">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="microfono">Micrófono</label>
+          <select id="microfono" name="microfono">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
 
-        <label class="check"><input type="checkbox" name="huella" /> <span>Huella</span></label>
-        <label class="check"><input type="checkbox" name="parlante" /> <span>Parlante</span></label>
+        <div class="field">
+          <label for="huella">Huella</label>
+          <select id="huella" name="huella">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="parlante">Parlante</label>
+          <select id="parlante" name="parlante">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
 
-        <label class="check"><input type="checkbox" name="senal" /> <span>Senal</span></label>
-        <label class="check"><input type="checkbox" name="vibrador" /> <span>Vibrador</span></label>
+        <div class="field">
+          <label for="senal">Señal</label>
+          <select id="senal" name="senal">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="vibrador">Vibrador</label>
+          <select id="vibrador" name="vibrador">
+            <option value="si">Sí</option>
+            <option value="no">No</option>
+          </select>
+        </div>
       </div>
     </section>
 
     <!-- DESCRIPCIÓN -->
     <section class="section">
-      <h2 class="section__title">Descripción del problema</h2>
+      <h2 class="section__title">Descripción</h2>
       <div class="field">
         <label for="descripcion" class="sr-only">Descripción</label>
         <textarea id="descripcion" name="descripcion" rows="4" placeholder="Describe síntomas, historial, o condiciones del equipo..."></textarea>


### PR DESCRIPTION
## Summary
- Reworked service order form checklist to use Sí/No dropdowns and updated "Descripción" section heading.
- Introduced color palette variables and black-on-white section headers for consistent styling.
- Flash order ID after creation to persist autoincremented `id_orden`.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689bd3f67664832283c3e58878a37e0d